### PR TITLE
Fix build errors of issue #46

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,19 +34,14 @@ matrix:
           - gh-pages
 
     - language: scala
-      scala:
-        - 2.13.1
-        - 2.12.10
+      scala: 2.12.10
       jdk: openjdk8
-      sudo: false
-
-      script:
-        - if [[ "$TRAVIS_SCALA_VERSION" == 2.12.* ]];
-          then
-            sbt ++$TRAVIS_SCALA_VERSION  clean coverage test coverageReport && bash <(curl -s https://codecov.io/bash);
-          else
-            sbt ++$TRAVIS_SCALA_VERSION  clean test && echo "Skipping code coverage reporting and docs on 2.13";
-          fi
+      script: sbt ++$TRAVIS_SCALA_VERSION  clean coverage test coverageReport
 
       after_success:
         - bash <(curl -s https://codecov.io/bash)
+
+    - language: scala
+      scala: 2.13.1
+      jdk: openjdk8
+      script: sbt ++$TRAVIS_SCALA_VERSION  clean test && echo "Skipping code coverage reporting and docs on 2.13";

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,19 @@ matrix:
           - gh-pages
 
     - language: scala
-      scala: 2.13.1
+      scala:
+        - 2.13.1
+        - 2.12.10
       jdk: openjdk8
       sudo: false
 
       script:
-        - sbt clean coverage test coverageReport
+        - if [[ "$TRAVIS_SCALA_VERSION" == 2.12.* ]];
+          then
+            sbt ++$TRAVIS_SCALA_VERSION  clean coverage test coverageReport && bash <(curl -s https://codecov.io/bash);
+          else
+            sbt ++$TRAVIS_SCALA_VERSION  clean test && echo "Skipping code coverage reporting and docs on 2.13";
+          fi
 
       after_success:
         - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: xenial
+
 matrix:
   include:
     - language: python
@@ -34,14 +36,16 @@ matrix:
           - gh-pages
 
     - language: scala
-      scala: 2.12.10
-      jdk: openjdk8
+      scala:
+        - 2.12.10
+      jdk: openjdk12
       script: sbt ++$TRAVIS_SCALA_VERSION  clean coverage test coverageReport
 
       after_success:
         - bash <(curl -s https://codecov.io/bash)
 
     - language: scala
-      scala: 2.13.1
-      jdk: openjdk8
+      scala:
+        - 2.13.1
+      jdk: openjdk12
       script: sbt ++$TRAVIS_SCALA_VERSION  clean test && echo "Skipping code coverage reporting and docs on 2.13";

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,10 @@ name := "shExLite"
 
 version := "0.1"
 
-scalaVersion := "2.13.1"
-crossScalaVersions := Seq("2.12.10", "2.13.1")
+lazy val scala212 = "2.12.10"
+lazy val scala213 = "2.13.1"
+scalaVersion in ThisBuild := scala213
+crossScalaVersions := Seq(scala212, scala213)
 
 Compile / scalaSource := baseDirectory.value / "src"
 Compile / unmanagedSourceDirectories += baseDirectory.value / "src/library"

--- a/project/build.properties
+++ b/project/build.properties
@@ -20,4 +20,4 @@
 # The ShEx Lite Project includes packages written by third parties.
 #
 
-sbt.version = 1.1.1
+sbt.version = 1.3.7

--- a/src/compiler/semantic/MemoryErrorHandler.scala
+++ b/src/compiler/semantic/MemoryErrorHandler.scala
@@ -50,14 +50,14 @@ object MemoryErrorHandler extends ErrorHandler {
    *
    * @param error to add to the system.
    */
-  override def addError(error: Error): Unit = errors.addOne(error)
+  override def addError(error: Error): Unit = errors += error
 
   /**
    * Adds warnings to the error system.
    *
    * @param warning to add to the system.
    */
-  override def addWarning(warning: Warning): Unit = warnings.addOne(warning)
+  override def addWarning(warning: Warning): Unit = warnings += warning
 
   /**
    * Shows the errors through the terminal.

--- a/src/compiler/syntactic/ShExLSyntacticParser.scala
+++ b/src/compiler/syntactic/ShExLSyntacticParser.scala
@@ -29,7 +29,7 @@ import compiler.ast._
 import compiler.syntactic.generated.{ShexlBaseVisitor, ShexlLexer, ShexlParser}
 import org.antlr.v4.runtime.{CharStreams, CommonTokenStream}
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 class ShExLSyntacticParser(filename: String) extends ShexlBaseVisitor[ASTNode] {
 

--- a/test/unit/compiler/MemorySymbolTableUnitTest.scala
+++ b/test/unit/compiler/MemorySymbolTableUnitTest.scala
@@ -48,7 +48,7 @@ class MemorySymbolTableUnitTest extends AnyFunSuite with BeforeAndAfter {
   val shape = new ShapeDeclaration("example", 4,1,
     new PrefixInvocation("example", 4,2, "this is my shape name", prefix), null)
 
-  before {
+  after {
     MemorySymbolTable.restore()
     MemoryErrorHandler.restore()
   }

--- a/test/unit/compiler/semantic/IdentificationWalkerTest.scala
+++ b/test/unit/compiler/semantic/IdentificationWalkerTest.scala
@@ -34,7 +34,10 @@ class IdentificationWalkerTest extends AnyFunSuite with BeforeAndAfter {
 
   // In order to be sure that on each test case we do not have data from previous tests.
   after {
+    logger.debug("Restoring memory symbol table.")
     MemorySymbolTable.restore()
+
+    logger.debug("Restoring memory error handler.")
     MemoryErrorHandler.restore()
   }
 

--- a/test/unit/compiler/semantic/IdentificationWalkerTest.scala
+++ b/test/unit/compiler/semantic/IdentificationWalkerTest.scala
@@ -33,11 +33,8 @@ class IdentificationWalkerTest extends AnyFunSuite with BeforeAndAfter {
   final val logger = Logger[IdentificationWalkerTest]
 
   // In order to be sure that on each test case we do not have data from previous tests.
-  before {
-    logger.debug("Restoring memory symbol table.")
+  after {
     MemorySymbolTable.restore()
-
-    logger.debug("Restoring memory error handler.")
     MemoryErrorHandler.restore()
   }
 


### PR DESCRIPTION
Work done:
* I have restored the sbt version to 1.3.7. With that the following error is fixed: `The compiler bridge sources org.scala-sbt:compiler-bridge_2.13:1.1.1:compile could not be retrieved`.
* I have modified the project to be compatible with both Scala 2.12.10 and 2.13.1. This allows us to make two different Travis builds, one when the coverage is run (2.12.10) and the other one where just tests are run (2.13.1)
* I have submitted a temporal fix for the error where one test would fail when executing tests from the command line. The problem comes from the MemorySymbolTableUnitTest class. When running the test suite the tests from this class are executed before the IdentificationWalker tests, and the state of the MemoryErrorHandler was not restored, containing an error from the MemorySymbolTable tests. **In theory**, the state should be restored with the *before* method, but that was not the case. For now I substituted the before method for an after one, so after each test in the MemorySymbolTable suite the state is restored. This works right now, but we should open a new issue to look a the cause of this problem and propose a better solution.

Closes #46 