### PR TITLE
Add prefix declaration semantic validation and tests

### DIFF
--- a/src/compiler/semantic/IdentificationWalker.scala
+++ b/src/compiler/semantic/IdentificationWalker.scala
@@ -23,7 +23,7 @@
 package compiler.semantic
 
 import com.typesafe.scalalogging.Logger
-import compiler.ast.{BaseDeclaration, DefaultASTWalker, StartDeclaration}
+import compiler.ast.{BaseDeclaration, DefaultASTWalker, PrefixDeclaration, StartDeclaration}
 
 /**
  * The identification walker is the tool that travels the AST just to identify possible definitions an add the
@@ -62,5 +62,20 @@ class IdentificationWalker extends DefaultASTWalker {
 
     // Adds the start to the memory table. Policies about redefinition and other things are delegated to the ST.
     MemorySymbolTable.setStart(declaration, declaration)
+  }
+
+  /**
+   * Identifies a prefix declaration. Once this method is called to walk over an prefix declaration if delegates to the
+   * symbol table the action of adding it to the context or raising an error.
+   *
+   * @param declaration that is being walked and will be added to the symbol table.
+   * @param param is the parameter if any needed.
+   * @return either the prefix declaration if no error happen or a compile error otherwise.
+   */
+  override def walk(declaration: PrefixDeclaration, param: Any): Any = {
+    logger.debug(s"Walking over a prefix declaration [$declaration]")
+
+    // Ads the prefix ot the symbol table. Policies about redefinition and other things are delegated to the ST.
+    MemorySymbolTable.insert(declaration, declaration)
   }
 }

--- a/test/assets/correct_schema_using_prefix_1.shexl
+++ b/test/assets/correct_schema_using_prefix_1.shexl
@@ -1,0 +1,2 @@
+PREFIX : <http://google.es/>
+PREFIX xsd: <http://schema.org/>

--- a/test/assets/incorrect_schema_using_prefix_redefinition_1.shexl
+++ b/test/assets/incorrect_schema_using_prefix_redefinition_1.shexl
@@ -1,0 +1,4 @@
+PREFIX : <http://google.es/>
+PREFIX xsd: <http://schema.org/>
+
+PREFIX xsd: <http://overridingprefix.org/>

--- a/test/unit/compiler/semantic/IdentificationWalkerTest.scala
+++ b/test/unit/compiler/semantic/IdentificationWalkerTest.scala
@@ -138,4 +138,49 @@ class IdentificationWalkerTest extends AnyFunSuite with BeforeAndAfter {
     // Check that the actual value of the start in the symbol table has been updated and therefore is not null.
     assert(Objects.nonNull(MemorySymbolTable.getStart(null).getOrElse(null)))
   }
+
+  /**
+   * By default the redefinition of a prefix is not allowed. Therefore if the identification walker detects this case
+   * should delegate in the symbol table the creation of an error.
+   */
+  test("Check that a prefix redefinition is detected by the identification walker") {
+
+    // Parsing a sample file that contains a prefix redefinition.
+    val ast = new ShExLSyntacticParser("test/assets/incorrect_schema_using_prefix_redefinition_1.shexl").parse()
+
+    // Initially should not be any errors.
+    logger.debug(s"Memory Error Handler values before identification visitor: [${MemoryErrorHandler.toString()}].")
+    assert(!MemoryErrorHandler.hasErrors)
+
+    // Then we walk the AST and here the error should be generated.
+    ast.walk(new IdentificationWalker(), null)
+
+    // Check that the error have been generated.
+    logger.debug(s"Memory Error Handler values after identification visitor: [${MemoryErrorHandler.toString()}].")
+    assert(MemoryErrorHandler.hasErrors)
+  }
+
+  /**
+   * An prefix definition that is correctly defined in a schema should be identified by the identification walker, added
+   * to the corresponding symbol table and no errors should be generated.
+   */
+  test("Check that a prefix declaration is detected by the identification walker") {
+
+    // Parsing a sample file that contains a single start definition.
+    val ast = new ShExLSyntacticParser("test/assets/correct_schema_using_prefix_1.shexl").parse()
+
+    // Initially should not be any errors.
+    logger.debug(s"Memory Error Handler values before identification visitor: [${MemoryErrorHandler.toString()}].")
+    assert(!MemoryErrorHandler.hasErrors)
+
+    // Then we walk the AST and here no error should be generated.
+    ast.walk(new IdentificationWalker(), null)
+
+    // Check that no errors where generated.
+    logger.debug(s"Memory Error Handler values after identification visitor: [${MemoryErrorHandler.toString()}].")
+    assert(!MemoryErrorHandler.hasErrors)
+
+    // Check that the prefix value in the symbol table is right.
+    assert(MemorySymbolTable.getPrefix(null, "xsd").isRight)
+  }
 }


### PR DESCRIPTION
Adds the prefix declaration semantic identification and validations and the tests for it to validate the implementation.