### PR TITLE
[SLP-0093] Add license general collision statement

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -15,5 +15,7 @@ Except as otherwise noted (below and/or in individual files), ShEx Lite is
 licensed under the GNU, Version 3.0 <LICENSE-GNU> or
 <https://choosealicense.com/licenses/gpl-3.0/> or the MIT license
 <LICENSE-MIT> or <http://opensource.org/licenses/MIT>, at your option.
+In case of incompatibility between project licenses, GNU/GPLv3 will be
+applied.
 
 The ShEx Lite Project includes packages written by third parties.


### PR DESCRIPTION
Fix #91. Add the general collision line to ensure GNU/GPLv3 is used in case of licenses incompatibility.