### PR TITLE
[SLP-0113] Add automatic imports generation for the java std lib

### DIFF
--- a/src/compiler/es/weso/shexlc/codegen/javagen/CGJava02ClassGeneratorStage.scala
+++ b/src/compiler/es/weso/shexlc/codegen/javagen/CGJava02ClassGeneratorStage.scala
@@ -30,7 +30,7 @@ import es.weso.shexlc.ast.Schema
 import es.weso.shexlc.ast.expr.{CallBaseExpr, CallPrefixExpr}
 import es.weso.shexlc.ast.stmt.ShapeDefStmt
 import es.weso.shexlc.ast.visitor.DefaultShExLiteVisitor
-import es.weso.shexlc.codegen.javagen.internal.{CGJava03FieldsGenerator, CGJava04ConstructorGenerator, CGJava05GetSetGenerator}
+import es.weso.shexlc.codegen.javagen.internal.{CGJava021ImportGenerator, CGJava03FieldsGenerator, CGJava04ConstructorGenerator, CGJava05GetSetGenerator}
 import es.weso.shexlc.internal.io.CompilerMsgsHandler
 import es.weso.shexlc.internal.symboltable.SymbolTable
 
@@ -67,6 +67,9 @@ class CGJava02ClassGeneratorStage extends DefaultShExLiteVisitor[String] with Sh
     val fieldsGen = new CGJava03FieldsGenerator(msgsHandler, stringBuilder)
     val constructorGen = new CGJava04ConstructorGenerator(msgsHandler, stringBuilder)
     val getSetGen = new CGJava05GetSetGenerator(msgsHandler, stringBuilder)
+
+    // Imports generator
+    stmt.accept(new CGJava021ImportGenerator(msgsHandler, stringBuilder), null)
 
     stringBuilder.append(s"public class $className {")
     stringBuilder.append("\n")

--- a/src/compiler/es/weso/shexlc/codegen/javagen/internal/CGJava021ImportGenerator.scala
+++ b/src/compiler/es/weso/shexlc/codegen/javagen/internal/CGJava021ImportGenerator.scala
@@ -1,0 +1,17 @@
+package es.weso.shexlc.codegen.javagen.internal
+
+import es.weso.shexlc.ast.expr.CardinalityExpr
+import es.weso.shexlc.ast.visitor.DefaultShExLiteVisitor
+import es.weso.shexlc.internal.io.CompilerMsgsHandler
+
+class CGJava021ImportGenerator(msgsHandler: CompilerMsgsHandler, stringBuilder: StringBuilder)
+  extends DefaultShExLiteVisitor[String] {
+
+  override def visit(expr: CardinalityExpr, param: String): Unit = {
+    if(expr.max>1) {
+      stringBuilder.append("import java.util.List;")
+      stringBuilder.append("\n")
+      stringBuilder.append("\n")
+    }
+  }
+}

--- a/test/assets/input_correct_java_schema_user_car_1.shexl
+++ b/test/assets/input_correct_java_schema_user_car_1.shexl
@@ -10,5 +10,5 @@ prefix xsd: <schema.org>
 
 : Car {
     :plateNumber    xsd:string  ;
-    :owner          @:User
+    :owner          @:User?
 }

--- a/test/unit/es/weso/shexlc/test/unit/JavaCodeGenTest.scala
+++ b/test/unit/es/weso/shexlc/test/unit/JavaCodeGenTest.scala
@@ -50,6 +50,44 @@ class JavaCodeGenTest extends AnyFunSuite with BeforeAndAfter {
     }
   }
 
+  test("Compile a single file, generate code for it and test that the code is well generated.") {
+
+    val compiler = new ShExLCompilerImpl().setConfiguration(new ShExLCompilerConfig {
+      override def generateWarnings: Boolean = true
+      override def generateCode: Boolean = true
+    })
+
+    var compileResult =
+      compiler
+        .addSource("test/assets/input_correct_java_schema_user_car_1.shexl")
+        .compile.getCompilationResult
+
+    assert(!compileResult.hasErrors)
+    compileResult.getIndividualResults.foreach(result => result.getGeneratedSources.get(ShExLCompilerTargetLanguage.Java).get.foreach(source => println(source.getSource)))
+    val expected = "import java.util.List;\n\npublic class User {\n\tprivate String name;\n\tprivate String surname;\n\tprivate int age;\n\tprivate List<User> knows;\n\n\tpublic User(String name, String surname, int age, List<User> knows) {\n\t\tthis.name = name;\n\t\tthis.surname = surname;\n\t\tthis.age = age;\n\t\tthis.knows = knows;\n\t}\n\n\tpublic String getName() {\n\t\treturn this.name;\n\t}\n\n\tpublic void setName(String name) {\n\t\tthis.name = name;\n\t}\n\n\tpublic String getSurname() {\n\t\treturn this.surname;\n\t}\n\n\tpublic void setSurname(String surname) {\n\t\tthis.surname = surname;\n\t}\n\n\tpublic int getAge() {\n\t\treturn this.age;\n\t}\n\n\tpublic void setAge(int age) {\n\t\tthis.age = age;\n\t}\n\n\tpublic List<User> getKnows() {\n\t\treturn this.knows;\n\t}\n\n\tpublic void setKnows(List<User> knows) {\n\t\tthis.knows = knows;\n\t}\n\n}\npublic class Car {\n\tprivate String platenumber;\n\tprivate User owner;\n\n\tpublic Car(String platenumber, User owner) {\n\t\tthis.platenumber = platenumber;\n\t\tthis.owner = owner;\n\t}\n\n\tpublic String getPlatenumber() {\n\t\treturn this.platenumber;\n\t}\n\n\tpublic void setPlatenumber(String platenumber) {\n\t\tthis.platenumber = platenumber;\n\t}\n\n\tpublic User getOwner() {\n\t\treturn this.owner;\n\t}\n\n\tpublic void setOwner(User owner) {\n\t\tthis.owner = owner;\n\t}\n\n}\n"
+    val results = compileResult.getIndividualResults.head.getGeneratedSources.get(ShExLCompilerTargetLanguage.Java).get
+    val res_1 = results.toList(0).getSource
+    val res_2 = results.toList(1).getSource
+
+    assert((res_1+res_2).equals(expected))
+
+    compileResult =
+      compiler
+        .addSource("test/assets/incorrect_schema_big_schema_2.shexl")
+        .compile.getCompilationResult
+
+    assert(compileResult.hasErrors)
+
+    if(compileResult.hasErrors) {
+      //compileResult.getIndividualResults.foreach(result => result.getErrors.foreach(err => println(err.getMessage)))
+    } else {
+      assert(!compileResult.hasErrors)
+      //compileResult.getIndividualResults.foreach(result => result.getGeneratedSchema.head.accept(new PrettyPrintASTVisitor(), new StringBuilder()))
+    }
+
+    //compileResult.getIndividualResults.foreach(result => result.getGeneratedSources.get(ShExLCompilerTargetLanguage.Java).get.foreach(source => println(source.getSource)))
+  }
+
   private[this] def getListOfFiles(dir: String, startsWith: String): List[String] = {
     val file = new File(dir)
     file.listFiles.filter(_.isFile)

--- a/test/unit/es/weso/shexlc/test/unit/SchemaTest.scala
+++ b/test/unit/es/weso/shexlc/test/unit/SchemaTest.scala
@@ -31,16 +31,23 @@ class SchemaTest extends AnyFunSuite {
   test("individual file compilation") {
 
     val compiler = new ShExLCompilerImpl().setConfiguration(new ShExLCompilerConfig {
-      override def generateWarnings: Boolean = false
-      override def generateCode: Boolean = false
+      override def generateWarnings: Boolean = true
+      override def generateCode: Boolean = true
     })
 
     var compileResult =
       compiler
-        .addSource("test/assets/correct_schema_big_schema_2.shexl")
+        .addSource("test/assets/input_correct_java_schema_user_car_1.shexl")
         .compile.getCompilationResult
 
     assert(!compileResult.hasErrors)
+    compileResult.getIndividualResults.foreach(result => result.getGeneratedSources.get(ShExLCompilerTargetLanguage.Java).get.foreach(source => println(source.getSource)))
+    val expected = "import java.util.List;\n\npublic class User {\n\tprivate String name;\n\tprivate String surname;\n\tprivate int age;\n\tprivate List<User> knows;\n\n\tpublic User(String name, String surname, int age, List<User> knows) {\n\t\tthis.name = name;\n\t\tthis.surname = surname;\n\t\tthis.age = age;\n\t\tthis.knows = knows;\n\t}\n\n\tpublic String getName() {\n\t\treturn this.name;\n\t}\n\n\tpublic void setName(String name) {\n\t\tthis.name = name;\n\t}\n\n\tpublic String getSurname() {\n\t\treturn this.surname;\n\t}\n\n\tpublic void setSurname(String surname) {\n\t\tthis.surname = surname;\n\t}\n\n\tpublic int getAge() {\n\t\treturn this.age;\n\t}\n\n\tpublic void setAge(int age) {\n\t\tthis.age = age;\n\t}\n\n\tpublic List<User> getKnows() {\n\t\treturn this.knows;\n\t}\n\n\tpublic void setKnows(List<User> knows) {\n\t\tthis.knows = knows;\n\t}\n\n}\npublic class Car {\n\tprivate String platenumber;\n\tprivate User owner;\n\n\tpublic Car(String platenumber, User owner) {\n\t\tthis.platenumber = platenumber;\n\t\tthis.owner = owner;\n\t}\n\n\tpublic String getPlatenumber() {\n\t\treturn this.platenumber;\n\t}\n\n\tpublic void setPlatenumber(String platenumber) {\n\t\tthis.platenumber = platenumber;\n\t}\n\n\tpublic User getOwner() {\n\t\treturn this.owner;\n\t}\n\n\tpublic void setOwner(User owner) {\n\t\tthis.owner = owner;\n\t}\n\n}\n"
+    val results = compileResult.getIndividualResults.head.getGeneratedSources.get(ShExLCompilerTargetLanguage.Java).get
+    val res_1 = results.toList(0).getSource
+    val res_2 = results.toList(1).getSource
+
+    assert((res_1+res_2).equals(expected))
 
     compileResult =
       compiler


### PR DESCRIPTION
Adds a `CGJava021ImportGenerator` that checks if any cardinality will require a list and if so it adds the corresponding import declaration

- fixes #84