### PR TITLE
[SLP-0120] Update shex-lite CI to avoid markdown files and documentation folder

### DIFF
--- a/.github/workflows/shex-lite-ci.yml
+++ b/.github/workflows/shex-lite-ci.yml
@@ -1,6 +1,18 @@
 name: ShEx-Lite CI
 
-on: [push, pull_request]
+on:
+  # On pushes will ignore all doc files and all markdown files.
+  push:
+    paths-ignore: 
+      - '**.md'
+      - 'doc/**'
+  
+  # On pull requests will ignore all doc files and all markdown files.
+  pull_request:
+    paths-ignore: 
+      - '**.md'
+      - 'doc/**'
+  
 
 jobs:
   


### PR DESCRIPTION
Updates the CI acocrding to this [website](https://help.github.com/es/actions/reference/workflow-syntax-for-github-actions) in order not to trigger the CI builds if the changes are only on markdown files or in the documentation folder.